### PR TITLE
feat(tests): create a test file for fetch_data (#6)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,8 @@ pyparsing==3.1.4
 python-dateutil==2.9.0.post0
 python-decouple==3.8
 python-multipart==0.0.12
+pytest==8.3.3
+pytest-mock==3.14.0
 pytz==2024.2
 PyYAML==6.0.2
 ratelimit==2.2.1

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import patch
+from fetch_data import fetch_data
+
+
+ENDPOINT = 'https://apiv3.iucnredlist.org/api/v3/'
+
+
+class TestFetchData:
+
+    # Test fetching version
+    def test_fetch_data_version(self):
+        endpoint = ENDPOINT + 'version'
+        result = fetch_data(endpoint)
+
+        assert isinstance(result, dict)
+        assert result.get('version') is not None
+
+    # Test fetching country list (No token)
+    def test_fetch_country_list_failure_no_token(self):
+        endpoint = ENDPOINT + 'country/list'
+        result = fetch_data(endpoint)
+
+        assert isinstance(result, dict)
+        assert result.get('error') is not None
+
+    # Test fetching country list with incorrect token (Expect 500)
+    @patch('fetch_data.requests.get')
+    def test_fetch_country_list_failure_incorrect_token(self, mock_get):
+        # Mocking a 500 response
+        mock_get.return_value.status_code = 500
+        mock_get.return_value.json.return_value = {
+            "error": "Internal Server Error"}
+
+        endpoint = ENDPOINT + 'country/list?token=69'
+        result = fetch_data(endpoint)
+
+        # Ensure fetch_data handles 500 properly
+        assert result is None or result.get('error') == "Internal Server Error"


### PR DESCRIPTION
- [x] Create a pytest file for **fetch_data.py**

```shell
pytest -v
``` 

![image](https://github.com/user-attachments/assets/d98d7db2-214e-460f-9dcb-1966d75bd5bc)

Unfortunately, **https://apiv3.iucnredlist.org/api/v3/token** cannot be used to generate an API token; therefore, I could only test generic endpoints on **fetch_data.py**, not **tracker.py**.

